### PR TITLE
Fix proactivity spawn prompt quoting on Windows (0.5.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.5 - 2026-04-20
+
+### Fixed
+
+- Morning proactivity spawn on Windows no longer fragments the prompt. The spawn command quoted inner paths and placeholders (`"{brief_path}"`, `"{job_id}"`, `--error "<concrete error>"`) with double quotes, which `quote_for_cmd` then doubled to `""..."".` cmd interpreted each `""` as quote-close-then-open and split the prompt into 28+ separate tokens, so the spawned Claude session received stray args like `--error` and `--summary` and rejected them. The prompt now uses single quotes around placeholders, which cmd passes through verbatim, so the whole prompt reaches the spawned session as one intact argument.
+- Pairs with a companion fix to the user's `claude.ps1` wrapper (separate file, outside this repo) that dropped `[Parameter(ValueFromRemainingArguments)]` to keep the script a plain script instead of an advanced function — otherwise PowerShell matched `--error` against auto-added common parameters (`-ErrorAction`/`-ErrorVariable`) and crashed with AmbiguousParameter before the prompt ever reached claude.exe.
+
 ## 0.5.4 - 2026-04-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Morning proactivity spawn on Windows no longer fragments the prompt. The spawn command quoted inner paths and placeholders (`"{brief_path}"`, `"{job_id}"`, `--error "<concrete error>"`) with double quotes, which `quote_for_cmd` then doubled to `""..."".` cmd interpreted each `""` as quote-close-then-open and split the prompt into 28+ separate tokens, so the spawned Claude session received stray args like `--error` and `--summary` and rejected them. The prompt now uses single quotes around placeholders, which cmd passes through verbatim, so the whole prompt reaches the spawned session as one intact argument.
+- Claude proactivity launches now preserve the inherited Claude/Anthropic environment instead of clearing `CLAUDECODE`, `ANTHROPIC_API_KEY`, and `ANTHROPIC_AUTH_TOKEN` before starting the spawned session.
 - Pairs with a companion fix to the user's `claude.ps1` wrapper (separate file, outside this repo) that dropped `[Parameter(ValueFromRemainingArguments)]` to keep the script a plain script instead of an advanced function — otherwise PowerShell matched `--error` against auto-added common parameters (`-ErrorAction`/`-ErrorVariable`) and crashed with AmbiguousParameter before the prompt ever reached claude.exe.
 
 ## 0.5.4 - 2026-04-20

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "munin-memory"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "automod",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "munin-memory"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 autobins = false
 authors = ["John McKeown"]

--- a/src/analytics/memory_os_cmd.rs
+++ b/src/analytics/memory_os_cmd.rs
@@ -3521,9 +3521,19 @@ fn render_correction_patterns_to_codify(patterns: &[MemoryOsCorrectionPatternSum
         return;
     }
     for (index, pattern) in filtered.iter().enumerate() {
-        let wrong = pattern.wrong_command.split_whitespace().collect::<Vec<_>>().join(" ");
-        let corrected = pattern.corrected_command.split_whitespace().collect::<Vec<_>>().join(" ");
-        let status = if pattern.successful_replays > pattern.failed_replays && pattern.successful_replays >= pattern.count {
+        let wrong = pattern
+            .wrong_command
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        let corrected = pattern
+            .corrected_command
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        let status = if pattern.successful_replays > pattern.failed_replays
+            && pattern.successful_replays >= pattern.count
+        {
             "replaying-clean"
         } else {
             "uncodified"
@@ -3552,11 +3562,20 @@ fn command_diff_display(wrong: &str, corrected: &str, max_tail: usize) -> (Strin
         let wrong_tail = tail_from(wrong, common, max_tail);
         let corrected_tail = tail_from(corrected, common, max_tail);
         (
-            format!("[shared {}ch: `{}...`] ...{}", common, shared_preview, wrong_tail),
-            format!("[shared {}ch: `{}...`] ...{}", common, shared_preview, corrected_tail),
+            format!(
+                "[shared {}ch: `{}...`] ...{}",
+                common, shared_preview, wrong_tail
+            ),
+            format!(
+                "[shared {}ch: `{}...`] ...{}",
+                common, shared_preview, corrected_tail
+            ),
         )
     } else {
-        (display_text(wrong, max_tail), display_text(corrected, max_tail))
+        (
+            display_text(wrong, max_tail),
+            display_text(corrected, max_tail),
+        )
     }
 }
 

--- a/src/core/proactivity.rs
+++ b/src/core/proactivity.rs
@@ -1964,7 +1964,7 @@ fn build_launch_command(
         })
         .unwrap_or_default();
     let prompt = format!(
-        "{token}. The daemon already claimed the job. Read the brief at \"{brief_path}\".{leading_task} When you finish, run: munin proactivity complete --job-id \"{job_id}\" --status complete --summary \"<one sentence summary>\". On failure run: munin proactivity complete --job-id \"{job_id}\" --status failed --summary \"<short failure summary>\" --error \"<concrete error>\". Full instructions are also at \"{launch_path}\".",
+        "{token}. The daemon already claimed the job. Read the brief at '{brief_path}'.{leading_task} When you finish, run: munin proactivity complete --job-id '{job_id}' --status complete --summary '<one sentence summary>'. On failure run: munin proactivity complete --job-id '{job_id}' --status failed --summary '<short failure summary>' --error '<concrete error>'. Full instructions are also at '{launch_path}'.",
         token = MORNING_PROMPT_TOKEN,
         job_id = job.job_id,
         brief_path = job.brief_path,

--- a/src/core/proactivity.rs
+++ b/src/core/proactivity.rs
@@ -1982,7 +1982,7 @@ fn build_launch_command(
                 "claude-opus-4-6",
                 &prompt,
             ],
-            &["CLAUDECODE", "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"],
+            &[],
         ),
         ProactivityProvider::Codex => build_provider_launch_command(
             &job.session_name,
@@ -2925,6 +2925,9 @@ mod tests {
             .preview
             .contains("Start with this intervention: Fix friction"));
         assert!(launch.preview.contains("Work it until implemented"));
+        assert!(!launch.preview.contains("set CLAUDECODE="));
+        assert!(!launch.preview.contains("set ANTHROPIC_API_KEY="));
+        assert!(!launch.preview.contains("set ANTHROPIC_AUTH_TOKEN="));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Morning proactivity spawn on Windows was shipping a fragmented prompt to the spawned Claude session.

**Before:** inner placeholders (`"{brief_path}"`, `"{job_id}"`, `--error "<concrete error>"`) used double quotes. `quote_for_cmd` doubled them to `""..."".` cmd interpreted each `""` as quote-close-then-open and split the prompt into 28+ separate tokens. The spawned session received stray args like `--error`, `--summary`, `--job-id` as bare CLI flags and rejected them before ever reading the brief.

**After:** placeholders use single quotes. cmd doesn't treat `'` as a quote char, so the whole prompt survives as one intact argument.

This PR also folds the Claude-side proactivity fix into Munin: Claude proactivity launches now preserve the inherited Claude/Anthropic environment instead of clearing `CLAUDECODE`, `ANTHROPIC_API_KEY`, and `ANTHROPIC_AUTH_TOKEN` before starting the spawned session.

## Companion fix (outside this repo)

The original failure also surfaced as `AmbiguousParameter: error` in the user's local `~/bin/claude.ps1` wrapper, because `[Parameter(ValueFromRemainingArguments)]` made the script an advanced function and PowerShell auto-added `-ErrorAction`/`-ErrorVariable`. That wrapper was patched separately to use `$args` directly. With both fixes in place, the full chain (munin spawn → cmd → claude.cmd → claude.ps1 → claude.exe) delivers the prompt intact.

## Verification

- `cargo fmt --check`
- `cargo test --lib core::proactivity`: 17/17 pass
- `cargo build`
- `cargo test`: 313 lib tests, 14 integration tests, and 24 doc tests pass
- `munin proactivity run --no-spawn` preview now shows single-quoted placeholders, no `""`
- Simulated full spawn chain with `CLAUDE_WRAPPER_DEBUG=1`: prompt arrives as one intact `forwarded_args[3]` element

## Test plan

- [x] Proactivity unit tests pass
- [x] Full local Rust test suite passes
- [x] `cargo fmt --check` passes
- [x] `munin proactivity run --no-spawn` preview format matches expected single-quote shape
- [x] Wrapper chain forwards embedded `--error` without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)