### PR TITLE
feat: release Munin 0.5.7 friction monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.5.7 - 2026-04-22
+
+### Added
+
+- `munin friction --format text` now includes a `New But Unproven Friction Points` section for high-signal corrections that should be avoided immediately, even before they are repeated enough to become codified friction fixes.
+
+### Fixed
+
+- Strategy discovery now treats `strategic-plan.context.json` as the authoritative OPSP artifact, including standalone `strategy/` folders and legacy Context strategy stores.
+- `munin strategy status` and Session Brain can now read a formal OPSP JSON sidecar directly instead of falling back to Memory OS prose when no Munin registry/kernel wrapper is configured.
+
 ## 0.5.6 - 2026-04-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "munin-memory"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "anyhow",
  "automod",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "munin-memory"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2021"
 rust-version = "1.78"
 autobins = false

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ commands, and Codex skills. It is designed for developers who want agents to
 remember active work, repeated mistakes, strategic priorities, and unfinished
 tasks without sending that memory to a hosted service.
 
-Current release: `v0.5.6`.
+Current release: `v0.5.7`.
 
 [![CI](https://github.com/inchwormz/munin-memory/actions/workflows/ci.yml/badge.svg)](https://github.com/inchwormz/munin-memory/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/munin-memory.svg)](https://crates.io/crates/munin-memory)

--- a/docs/release/v0.5.7.md
+++ b/docs/release/v0.5.7.md
@@ -1,0 +1,27 @@
+# Munin v0.5.7
+
+Munin v0.5.7 fixes formal strategy discovery and improves friction reporting
+for newly observed high-signal corrections.
+
+## Highlights
+
+- `strategic-plan.context.json` is now treated as the authoritative OPSP
+  artifact.
+- Standalone workspace `strategy/` folders are discovered without requiring a
+  pre-existing registry/kernel wrapper.
+- Legacy Context strategy stores are discovered as read-compatible sources.
+- Session Brain now prefers formal OPSP KPIs and initiatives over partial Memory
+  OS strategy prose when a JSON sidecar is present.
+- `munin friction --format text` now includes `New But Unproven Friction Points`
+  so single or newly detected high-signal corrections can be avoided before they
+  become repeated/codified friction.
+
+## Verification
+
+- `cargo fmt`
+- `cargo test`
+- `cargo build --release`
+- `cargo run --locked --bin munin -- install --check-resolvable`
+- `cargo package`
+- `cargo publish --dry-run`
+

--- a/src/analytics/memory_os_cmd.rs
+++ b/src/analytics/memory_os_cmd.rs
@@ -3246,6 +3246,31 @@ fn apply_friction_filters(
             .unwrap_or(true);
         agent_matches && time_matches
     });
+    report.new_unproven_friction.retain(|fix| {
+        let combined = format!(
+            "{} {} {} {} {}",
+            fix.title,
+            fix.summary,
+            fix.permanent_fix,
+            fix.status,
+            fix.evidence.join(" ")
+        )
+        .to_lowercase();
+        let agent_matches = agent
+            .as_deref()
+            .map(|needle| combined.contains(needle))
+            .unwrap_or(true);
+        let time_matches = since
+            .map(|since| {
+                fix.evidence.iter().any(|line| {
+                    first_rfc3339_timestamp(line)
+                        .map(|timestamp| timestamp >= since)
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(true);
+        agent_matches && time_matches
+    });
     report.by_source.clear();
     report.redirects = crate::core::memory_os::MemoryOsRedirectSummary::default();
     report.repeated_corrections.clear();
@@ -3312,6 +3337,11 @@ fn render_friction_text(report: &MemoryOsFrictionReport) {
     println!("Top Friction Fixes");
     println!("------------------");
     render_friction_fixes(&report.top_fixes);
+    println!();
+    println!("New But Unproven Friction Points");
+    println!("--------------------------------");
+    println!("Single or newly detected high-signal corrections worth avoiding, but not yet promoted to recurring friction.");
+    render_new_unproven_friction(&report.new_unproven_friction);
     println!();
     println!("By Source");
     println!("---------");
@@ -3432,6 +3462,27 @@ fn render_friction_fixes(fixes: &[MemoryOsFrictionFix]) {
     }
     if non_fixed.is_empty() && fixed_count == 0 {
         println!("- none");
+    }
+}
+
+fn render_new_unproven_friction(fixes: &[MemoryOsFrictionFix]) {
+    if fixes.is_empty() {
+        println!("- none");
+        return;
+    }
+    for (index, fix) in fixes.iter().enumerate() {
+        println!(
+            "{}. [{}|{}] {}",
+            index + 1,
+            fix.impact,
+            fix.status,
+            display_text(&fix.title, 110)
+        );
+        println!("   why it matters: {}", display_text(&fix.summary, 180));
+        println!("   avoid by: {}", display_text(&fix.permanent_fix, 220));
+        for evidence in fix.evidence.iter().take(2) {
+            println!("   evidence: {}", display_text(evidence, 160));
+        }
     }
 }
 

--- a/src/core/access_layer/intent_rules.rs
+++ b/src/core/access_layer/intent_rules.rs
@@ -142,6 +142,7 @@ pub const INTENT_RULES: &[IntentRule] = &[
         output_contract: &["top fixes", "status", "permanent fix", "evidence"],
         trust_rules: &[
             "`active` and `codified` are current friction.",
+            "`monitoring` in New But Unproven Friction Points is a single or newly detected high-signal correction worth avoiding, not yet proven enough for a codified fix.",
             "`monitoring`, `fixed`, and `retired` are background unless the user asks for history.",
             "Every surfaced fix should include its permanent-fix pointer when present.",
         ],
@@ -151,7 +152,7 @@ pub const INTENT_RULES: &[IntentRule] = &[
             "If the report looks stale, run doctor before turning it into user guidance.",
         ],
         done_criteria: &[
-            "Lists the top 1-3 active/codified issues.",
+            "Lists the top 1-3 active/codified issues and any monitoring one-off points when present.",
             "Includes each issue's permanent-fix pointer.",
             "Mentions retired/fixed items only when asked or when explaining empty current friction.",
         ],

--- a/src/core/memory_os.rs
+++ b/src/core/memory_os.rs
@@ -523,6 +523,7 @@ pub struct MemoryOsFrictionReport {
     pub generated_at: String,
     pub scope: MemoryOsInspectionScope,
     pub top_fixes: Vec<MemoryOsFrictionFix>,
+    pub new_unproven_friction: Vec<MemoryOsFrictionFix>,
     pub by_source: Vec<MemoryOsSourceBehaviorSummary>,
     pub redirects: MemoryOsRedirectSummary,
     pub repeated_corrections: Vec<MemoryOsCorrectionPatternSummary>,

--- a/src/core/strategy.rs
+++ b/src/core/strategy.rs
@@ -1,5 +1,6 @@
 //! Minimal durable business-strategy kernel and scorecard support.
 use super::config::{context_data_dir, Config, StrategyScopeConfig};
+use super::constants::LEGACY_CONTEXT_DATA_DIR;
 use crate::core::memory_os::MemoryOsInspectionScope;
 use crate::core::tracking::Tracker;
 use anyhow::{anyhow, Context, Result};
@@ -615,66 +616,13 @@ pub fn default_strategy_scope_hint() -> String {
 
 pub fn discover_inspect_reports(limit: usize) -> Result<Vec<StrategyInspectReport>> {
     let config = Config::load().context("Failed to load config.toml")?;
-    let strategy_root = config
-        .strategy
-        .directory
-        .clone()
-        .unwrap_or(context_data_dir()?.join(STRATEGY_DIR));
-    let mut scope_dirs = BTreeMap::new();
-
-    for scope_name in config.strategy.scopes.keys() {
-        scope_dirs.insert(scope_name.clone(), strategy_root.join(scope_name));
-    }
-
-    if let Some(default_scope) = config.strategy.configured_scope_name(None) {
-        scope_dirs
-            .entry(default_scope.clone())
-            .or_insert_with(|| strategy_root.join(default_scope));
-    }
-
-    if strategy_root.exists() {
-        for entry in fs::read_dir(&strategy_root)? {
-            let entry = entry?;
-            if !entry.file_type()?.is_dir() {
-                continue;
-            }
-            let scope_name = entry.file_name().to_string_lossy().to_string();
-            scope_dirs.entry(scope_name).or_insert_with(|| entry.path());
-        }
-    }
+    let scope_dirs = discover_strategy_storage_dirs(&config)?;
 
     let mut reports = Vec::new();
     for (scope_name, storage_dir) in scope_dirs {
-        let registry_path = storage_dir.join(STRATEGY_REGISTRY_FILE);
-        let kernel_path = storage_dir.join(STRATEGY_KERNEL_FILE);
-        if !registry_path.exists() || !kernel_path.exists() {
-            continue;
+        if let Some(report) = inspect_report_from_storage_dir(&scope_name, &storage_dir)? {
+            reports.push(report);
         }
-        let registry = match load_registry(&registry_path) {
-            Ok(registry) => registry,
-            Err(_) => continue,
-        };
-        let mut kernel = match load_kernel(&kernel_path) {
-            Ok(kernel) => kernel,
-            Err(_) => continue,
-        };
-        if strategy_kernel_is_empty(&kernel) && registry.artifact_path.exists() {
-            if let Ok(imported) =
-                import_strategy_kernel(&registry.scope_id, &registry.artifact_path)
-            {
-                kernel = imported;
-            }
-        }
-        reports.push(StrategyInspectReport {
-            generated_at: Utc::now().to_rfc3339(),
-            scope_id: if registry.scope_id.trim().is_empty() {
-                scope_name
-            } else {
-                registry.scope_id.clone()
-            },
-            registry,
-            kernel,
-        });
     }
 
     reports.sort_by(|left, right| {
@@ -1009,30 +957,54 @@ fn load_scope_bundle(
     let paths = if let Some((_, scope_config)) = config.strategy.scope(Some(&scope_name)) {
         resolve_store_paths(&config, &scope_name, scope_config)?
     } else {
-        let strategy_root = config
-            .strategy
-            .directory
-            .clone()
-            .unwrap_or(context_data_dir()?.join(STRATEGY_DIR));
-        let storage_dir = strategy_root.join(&scope_name);
-        if !storage_dir.exists() {
-            return Err(anyhow!(
-                "No strategy scope is configured for `{scope_name}`"
-            ));
+        match discovered_store_paths(&config, &scope_name)? {
+            Some(paths) => paths,
+            None => {
+                return Err(anyhow!(
+                    "No strategy scope is configured for `{scope_name}`"
+                ))
+            }
         }
-        let fallback_scope = StrategyScopeConfig {
-            storage_dir: Some(storage_dir),
-            ..StrategyScopeConfig::default()
-        };
-        resolve_store_paths(&config, &scope_name, &fallback_scope)?
     };
-    let registry = load_registry(&paths.registry_path)?;
-    let mut kernel = load_kernel(&paths.kernel_path)?;
-    if strategy_kernel_is_empty(&kernel) && registry.artifact_path.exists() {
-        kernel = import_strategy_kernel(&registry.scope_id, &registry.artifact_path)?;
-        save_kernel(&paths.kernel_path, &kernel)?;
+    let registry_path = paths.registry_path.clone();
+    let kernel_path = paths.kernel_path.clone();
+    if registry_path.exists() && kernel_path.exists() {
+        let registry = load_registry(&registry_path)?;
+        let mut kernel = load_kernel(&kernel_path)?;
+        if strategy_kernel_is_empty(&kernel) && registry.artifact_path.exists() {
+            kernel = import_strategy_kernel(&registry.scope_id, &registry.artifact_path)?;
+            save_kernel(&kernel_path, &kernel)?;
+        }
+        return Ok((paths, registry, kernel));
     }
-    Ok((paths, registry, kernel))
+
+    let report = inspect_report_from_storage_dir(&scope_name, &paths.storage_dir)?
+        .ok_or_else(|| anyhow!("No strategy scope is configured for `{scope_name}`"))?;
+    Ok((paths, report.registry, report.kernel))
+}
+
+fn discovered_store_paths(
+    config: &Config,
+    requested_scope: &str,
+) -> Result<Option<StrategyStorePaths>> {
+    for (scope_name, storage_dir) in discover_strategy_storage_dirs(config)? {
+        let report = match inspect_report_from_storage_dir(&scope_name, &storage_dir)? {
+            Some(report) => report,
+            None => continue,
+        };
+        if requested_scope == crate::core::config::DEFAULT_STRATEGY_SCOPE
+            || report.scope_id == requested_scope
+            || scope_name == requested_scope
+        {
+            return Ok(Some(StrategyStorePaths {
+                registry_path: storage_dir.join(STRATEGY_REGISTRY_FILE),
+                kernel_path: storage_dir.join(STRATEGY_KERNEL_FILE),
+                metrics_path: report.registry.metrics_path.clone(),
+                storage_dir,
+            }));
+        }
+    }
+    Ok(None)
 }
 
 fn load_registry(path: &Path) -> Result<StrategySourceRegistry> {
@@ -1040,6 +1012,154 @@ fn load_registry(path: &Path) -> Result<StrategySourceRegistry> {
         .with_context(|| format!("Failed to read strategy registry {}", path.display()))?;
     serde_json::from_str(&content)
         .with_context(|| format!("Failed to parse strategy registry {}", path.display()))
+}
+
+fn discover_strategy_storage_dirs(config: &Config) -> Result<BTreeMap<String, PathBuf>> {
+    let mut scope_dirs = BTreeMap::new();
+    for strategy_root in strategy_root_candidates(config)? {
+        scope_dirs.insert(
+            format!("__standalone:{}", strategy_root.display()),
+            strategy_root.clone(),
+        );
+
+        for scope_name in config.strategy.scopes.keys() {
+            scope_dirs
+                .entry(scope_name.clone())
+                .or_insert_with(|| strategy_root.join(scope_name));
+        }
+
+        if let Some(default_scope) = config.strategy.configured_scope_name(None) {
+            scope_dirs
+                .entry(default_scope.clone())
+                .or_insert_with(|| strategy_root.join(default_scope));
+        }
+
+        if strategy_root.exists() {
+            for entry in fs::read_dir(&strategy_root)? {
+                let entry = entry?;
+                if !entry.file_type()?.is_dir() {
+                    continue;
+                }
+                let scope_name = entry.file_name().to_string_lossy().to_string();
+                scope_dirs.entry(scope_name).or_insert_with(|| entry.path());
+            }
+        }
+    }
+    Ok(scope_dirs)
+}
+
+fn strategy_root_candidates(config: &Config) -> Result<Vec<PathBuf>> {
+    let mut roots = Vec::new();
+    if let Some(dir) = config.strategy.directory.clone() {
+        push_unique_path(&mut roots, dir);
+    }
+    push_unique_path(&mut roots, context_data_dir()?.join(STRATEGY_DIR));
+    if let Some(local_data) = dirs::data_local_dir() {
+        push_unique_path(
+            &mut roots,
+            local_data.join(LEGACY_CONTEXT_DATA_DIR).join(STRATEGY_DIR),
+        );
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        for ancestor in cwd.ancestors() {
+            push_unique_path(&mut roots, ancestor.join(STRATEGY_DIR));
+        }
+    }
+    Ok(roots)
+}
+
+fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    let key = normalize_strategy_path_key(&path);
+    if paths
+        .iter()
+        .any(|existing| normalize_strategy_path_key(existing) == key)
+    {
+        return;
+    }
+    paths.push(path);
+}
+
+fn normalize_strategy_path_key(path: &Path) -> String {
+    absolute_or_original(path)
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .replace('\\', "/")
+        .to_ascii_lowercase()
+}
+
+fn inspect_report_from_storage_dir(
+    scope_hint: &str,
+    storage_dir: &Path,
+) -> Result<Option<StrategyInspectReport>> {
+    let registry_path = storage_dir.join(STRATEGY_REGISTRY_FILE);
+    let kernel_path = storage_dir.join(STRATEGY_KERNEL_FILE);
+    if registry_path.exists() && kernel_path.exists() {
+        let registry = match load_registry(&registry_path) {
+            Ok(registry) => registry,
+            Err(_) => return Ok(None),
+        };
+        let mut kernel = match load_kernel(&kernel_path) {
+            Ok(kernel) => kernel,
+            Err(_) => return Ok(None),
+        };
+        if strategy_kernel_is_empty(&kernel) && registry.artifact_path.exists() {
+            if let Ok(imported) =
+                import_strategy_kernel(&registry.scope_id, &registry.artifact_path)
+            {
+                kernel = imported;
+            }
+        }
+        let scope_id = if registry.scope_id.trim().is_empty() {
+            scope_hint.to_string()
+        } else {
+            registry.scope_id.clone()
+        };
+        return Ok(Some(StrategyInspectReport {
+            generated_at: Utc::now().to_rfc3339(),
+            scope_id,
+            registry,
+            kernel,
+        }));
+    }
+
+    let artifact_path = storage_dir.join(STRATEGY_TEMPLATE_JSON_FILE);
+    if !artifact_path.exists() {
+        return Ok(None);
+    }
+    let scope_id = strategy_json_scope_id(&artifact_path)?
+        .filter(|scope| !scope.trim().is_empty())
+        .unwrap_or_else(|| scope_hint.trim_start_matches("__standalone:").to_string());
+    let kernel = import_strategy_kernel(&scope_id, &artifact_path)?;
+    let registry = StrategySourceRegistry {
+        schema_version: "strategy-registry-v1".to_string(),
+        scope_id: scope_id.clone(),
+        artifact_path: absolute_or_original(&artifact_path)?,
+        metrics_path: absolute_or_original(&storage_dir.join(STRATEGY_DEFAULT_METRICS_FILE))?,
+        continuity_project_path: None,
+        signal_paths: Vec::new(),
+        storage_dir: absolute_or_original(storage_dir)?,
+        bootstrap_requested: false,
+        template_managed: false,
+        imported_at: Utc::now().to_rfc3339(),
+    };
+    Ok(Some(StrategyInspectReport {
+        generated_at: Utc::now().to_rfc3339(),
+        scope_id,
+        registry,
+        kernel,
+    }))
+}
+
+fn strategy_json_scope_id(path: &Path) -> Result<Option<String>> {
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    let parsed: serde_json::Value =
+        serde_json::from_str(&content).context("Failed to parse strategy JSON sidecar")?;
+    Ok(parsed
+        .get("organization")
+        .and_then(|value| value.get("scope_id"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string))
 }
 
 fn save_registry(path: &Path, registry: &StrategySourceRegistry) -> Result<()> {

--- a/src/core/tracking/reports.rs
+++ b/src/core/tracking/reports.rs
@@ -224,6 +224,8 @@ impl Tracker {
             prose_signal_counts.autonomy,
             Some(autonomy_status.as_str()),
         );
+        let new_unproven_friction =
+            super::signals::build_memory_os_new_unproven_friction(&checkpoints);
         let top_fixes = build_memory_os_friction_fixes(
             &correction_patterns,
             &likely_misunderstandings,
@@ -237,6 +239,7 @@ impl Tracker {
             generated_at: Utc::now().to_rfc3339(),
             scope,
             top_fixes,
+            new_unproven_friction,
             by_source,
             redirects,
             repeated_corrections: correction_patterns.into_iter().take(8).collect(),

--- a/src/core/tracking/signals.rs
+++ b/src/core/tracking/signals.rs
@@ -260,21 +260,7 @@ pub(super) fn count_user_prose_signals(
         .iter()
         .filter(|checkpoint| checkpoint.capture.profile == "session-onboarding")
     {
-        for text in checkpoint
-            .capture
-            .goal
-            .iter()
-            .chain(checkpoint.capture.reentry.current_recommendation.iter())
-            .map(|value| value.as_str())
-            .chain(
-                checkpoint
-                    .capture
-                    .selected_items
-                    .iter()
-                    .filter(|item| item.section == "user_prompts")
-                    .map(|item| item.summary.as_str()),
-            )
-        {
+        for text in checkpoint_user_prose(checkpoint) {
             let signal_key = compact_display_text(text, 220).to_ascii_lowercase();
             let lowered = text.to_ascii_lowercase();
             if lowered.contains("command noise")
@@ -401,6 +387,76 @@ fn user_prose_friction_fixes(
     fixes
 }
 
+pub(super) fn build_memory_os_new_unproven_friction(
+    checkpoints: &[MemoryOsCheckpointEnvelope],
+) -> Vec<crate::core::memory_os::MemoryOsFrictionFix> {
+    let mut wrong_terminal_evidence = Vec::new();
+    let mut wrong_terminal_seen = HashSet::new();
+
+    for checkpoint in checkpoints
+        .iter()
+        .filter(|checkpoint| checkpoint.capture.profile == "session-onboarding")
+    {
+        for text in checkpoint_user_prose(checkpoint) {
+            let lowered = text.to_ascii_lowercase();
+            if text_has_wrong_terminal_clarification_signal(&lowered) {
+                let key = compact_display_text(text, 180).to_ascii_lowercase();
+                if wrong_terminal_seen.insert(key) {
+                    push_unique_string(
+                        &mut wrong_terminal_evidence,
+                        format!("user correction at {}", checkpoint.capture.generated_at),
+                    );
+                }
+            }
+        }
+    }
+
+    if wrong_terminal_evidence.is_empty() {
+        return Vec::new();
+    }
+
+    vec![crate::core::memory_os::MemoryOsFrictionFix {
+        fix_id: "friction:new-unproven:clarify-context-reversal".to_string(),
+        title: "Clarify before reversing direction on likely wrong-terminal context slips"
+            .to_string(),
+        impact: "high".to_string(),
+        status: "monitoring".to_string(),
+        summary: format!(
+            "User corrected a likely wrong-terminal/context-slip interpretation {} time(s).",
+            wrong_terminal_seen.len()
+        ),
+        permanent_fix:
+            "When a user message reverses the current task framing or sounds like it may belong to another terminal, ask one concise clarifying question before editing."
+                .to_string(),
+        evidence: wrong_terminal_evidence.into_iter().take(3).collect(),
+        score: 90 + wrong_terminal_seen.len().min(10) as i64,
+    }]
+}
+
+fn checkpoint_user_prose(checkpoint: &MemoryOsCheckpointEnvelope) -> impl Iterator<Item = &str> {
+    checkpoint
+        .capture
+        .goal
+        .iter()
+        .map(|value| value.as_str())
+        .chain(
+            checkpoint
+                .capture
+                .reentry
+                .current_recommendation
+                .iter()
+                .map(|value| value.as_str()),
+        )
+        .chain(
+            checkpoint
+                .capture
+                .selected_items
+                .iter()
+                .filter(|item| item.section == "user_prompts")
+                .map(|item| item.summary.as_str()),
+        )
+}
+
 fn counts_latest_at(current: &mut Option<DateTime<Utc>>, candidate: DateTime<Utc>) {
     match current {
         Some(existing) if *existing >= candidate => {}
@@ -422,6 +478,23 @@ fn text_has_autonomy_signal(lowered: &str) -> bool {
         || lowered.contains("infinite task")
         || lowered.contains("don't stop")
         || lowered.contains("dont stop")
+}
+
+fn text_has_wrong_terminal_clarification_signal(lowered: &str) -> bool {
+    lowered.contains("wrong terminal")
+        || lowered.contains("typed this in the wrong")
+        || lowered.contains("context slip")
+        || (lowered.contains("clarifying question")
+            && (lowered.contains("before editing")
+                || lowered.contains("before touching")
+                || lowered.contains("before acting")
+                || lowered.contains("ask")
+                || lowered.contains("confirm")))
+        || (lowered.contains("ask")
+            && lowered.contains("confirm")
+            && (lowered.contains("revers")
+                || lowered.contains("wrong terminal")
+                || lowered.contains("mistake")))
 }
 
 fn text_has_autonomy_correction(lowered: &str) -> bool {
@@ -952,6 +1025,26 @@ mod tests {
                 .expect("timestamp")
                 .with_timezone(&Utc)
         );
+    }
+
+    #[test]
+    fn new_unproven_friction_surfaces_single_wrong_terminal_clarification() {
+        let checkpoints = vec![onboarding_checkpoint(
+            "2026-04-21T18:03:06Z",
+            "2026-04-21T18:03:10Z",
+            "that was a mistake that munin should hopefully catch, and you should recognise the user has typed this in the wrong terminal; ask a clarifying question first to confirm before editing",
+        )];
+
+        let fixes = build_memory_os_new_unproven_friction(&checkpoints);
+
+        assert_eq!(fixes.len(), 1);
+        assert_eq!(fixes[0].impact, "high");
+        assert_eq!(fixes[0].status, "monitoring");
+        assert!(fixes[0].title.contains("Clarify before reversing"));
+        assert!(fixes[0]
+            .permanent_fix
+            .contains("ask one concise clarifying question"));
+        assert!(fixes[0].evidence[0].contains("2026-04-21T18:03:06Z"));
     }
 
     #[test]

--- a/tests/golden/munin_friction_skill.md
+++ b/tests/golden/munin_friction_skill.md
@@ -27,6 +27,7 @@ munin doctor --scope user --format text
 
 ## Trust
 - `active` and `codified` are current friction.
+- `monitoring` in New But Unproven Friction Points is a single or newly detected high-signal correction worth avoiding, not yet proven enough for a codified fix.
 - `monitoring`, `fixed`, and `retired` are background unless the user asks for history.
 - Every surfaced fix should include its permanent-fix pointer when present.
 
@@ -43,6 +44,6 @@ munin doctor --scope user --format text
 
 ## Done
 You're done when the answer:
-- Lists the top 1-3 active/codified issues.
+- Lists the top 1-3 active/codified issues and any monitoring one-off points when present.
 - Includes each issue's permanent-fix pointer.
 - Mentions retired/fixed items only when asked or when explaining empty current friction.


### PR DESCRIPTION
## Summary
- Adds a New But Unproven Friction Points section to the friction text report.
- Surfaces the wrong-terminal/context-slip clarification pattern as high-signal monitoring friction.
- Folds in the 0.5.7 strategy discovery release metadata and release notes.

## Test plan
- [x] cargo fmt
- [x] cargo test
- [x] cargo build --release
- [x] cargo run --locked --bin munin -- install --check-resolvable
- [x] cargo package
- [x] cargo publish --dry-run

## Release
- Crates.io target: munin-memory v0.5.7
- Release notes: docs/release/v0.5.7.md